### PR TITLE
Let rendered children unmount before removing the portal node

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,5 @@
 import { Component } from 'react';
-import { render } from 'react-dom';
+import { render, unmountComponentAtNode } from 'react-dom';
 
 class PortalWrap extends Component {
 
@@ -29,6 +29,7 @@ class PortalWrap extends Component {
     }
 
     componentWillUnmount() {
+        unmountComponentAtNode(this.node);
         const parent = this.node.parentNode;
         parent.removeChild(this.node);
     }


### PR DESCRIPTION
My Modal components `componentWillUnmount` wasn't triggered when the PortalWrap was unmounted, adding a call to `ReactDOM.unmountComponentAtNode` before removing the node fixed it :)

Refs:
- https://facebook.github.io/react/blog/2015/10/01/react-render-and-top-level-api.html
- https://facebook.github.io/react/docs/react-dom.html#unmountcomponentatnode